### PR TITLE
Improve pay slider UI with separate day, week, month scales.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -222,6 +222,10 @@ h1, h2, h3, h4, h5, h6{
 
 }
 
+#outer-pay-amount-week, #outer-pay-amount-month {
+    display: none;
+}
+
 .btn-primary{
 
     background: #059;

--- a/index.html
+++ b/index.html
@@ -76,20 +76,52 @@
 
         <form id="input-form" role="form">
           <div class="form-group">
-            <label class="control-label lead question" for="pay-amount">How much do you pay your household worker?</label><br>
+            <label class="control-label lead question" for="pay-amount-day">How much do you pay your household worker?</label><br>
             <div class="row">
               <div class="col-sm-9">
-                <input
-                    id="pay-amount"
-                    class="slider"
-                    style="width: 100%;"
-                    type="text"
-                    name="pay-amount"
-                    data-slider-min="50"
-                    data-slider-max="8000"
-                    data-slider-step="10"
-                    value="500"
-                    data-slider-value="500"/>
+                  <input
+                  id="pay-amount"
+                  type="text"
+                   style="display: none;">
+                <div id="outer-pay-amount-day">
+                  <input
+                      id="pay-amount-day"
+                      class="slider"
+                      style="width: 100%;"
+                      type="text"
+                      name="pay-amount"
+                      data-slider-min="50"
+                      data-slider-max="600"
+                      data-slider-step="10"
+                      value="100"
+                      data-slider-value="100"/>
+                </div>
+                <div id="outer-pay-amount-week">
+                  <input
+                      id="pay-amount-week"
+                      class="slider"
+                      style="width: 100%;"
+                      type="text"
+                      name="pay-amount-week"
+                      data-slider-min="200"
+                      data-slider-max="3000"
+                      data-slider-step="50"
+                      value="500"
+                      data-slider-value="500"/>
+                </div>
+                <div id="outer-pay-amount-month">
+                  <input
+                      id="pay-amount-month"
+                      class="slider"
+                      style="width: 100%;"
+                      type="text"
+                      name="pay-amount-month"
+                      data-slider-min="1000"
+                      data-slider-max="13000"
+                      data-slider-step="50"
+                      value="2000"
+                      data-slider-value="2000"/>
+                </div>
               </div>
               <div class="col-sm-3">
                 <select class="selectpicker" name="pay-rate" data-width="100%" id="pay-rate">

--- a/js/main.js
+++ b/js/main.js
@@ -168,8 +168,8 @@ function update_display(class_name) {
 
 function validate_input(household_size, pay_rate, pay_amount) {
     if (!$.isNumeric(pay_amount)) {
-        $("#pay-amount").parents('.form-group').addClass('has-error');
-        $("#pay-amount").focus();
+        $("#pay-amount-" + pay_rate).parents('.form-group').addClass('has-error');
+        $("#pay-amount-" + pay_rate).focus();
         pay_amount = false;
     }
     if (household_size && pay_rate && pay_amount){
@@ -180,26 +180,47 @@ function validate_input(household_size, pay_rate, pay_amount) {
     return false
 }
 
+function update_sliders(rate) {
+    // Update all the sliders to show the equivalent of the matching value
+
+    $("#pay-amount-day").slider('setValue', $("#pay-amount").val() / constants.workdays_per_month, true);
+    $("#pay-amount-week").slider('setValue', $("#pay-amount").val() / constants.weeks_per_month, true);
+    $("#pay-amount-month").slider('setValue', parseFloat($("#pay-amount").val()), true);
+
+    // Hide all sliders.
+    $("#outer-pay-amount-day").hide();
+    $("#outer-pay-amount-week").hide();
+    $("#outer-pay-amount-month").hide();
+    
+    // Show the slider matching the selected rate.
+    $("#outer-pay-amount-" + rate).show();
+}
 
 function update_output() {
 
     // read input
     var household_size = $("#household-size").val();
     var pay_rate = $("#pay-rate").val();
-    var pay_amount = $("#pay-amount").val();
-
+    var pay_amount = $("#pay-amount-" + pay_rate).val();
+    
     if (validate_input(household_size, pay_rate, pay_amount)) {
         var monthly_expenditure = calculate_expenditure(household_size);
 
         // calculate monthly pay
         var monthly_pay = 0;
         // Assumption using DoL info - a month includes 4.33 weeks and a week is for 5 work days.
-        if (pay_rate == "day")
+        if (pay_rate == "day") {
             monthly_pay = pay_amount * constants.workdays_per_month;
-        else if (pay_rate == "week")
+        }
+        else if (pay_rate == "week") {
             monthly_pay = pay_amount * constants.weeks_per_month;
-        else if (pay_rate == "month")
+        }
+        else if (pay_rate == "month") {
             monthly_pay = pay_amount;
+        }
+
+        // Update the overall pay-amount input box.
+        $("#pay-amount").val(monthly_pay);
 
         var output_percentage = (monthly_pay / monthly_expenditure);
         output_percentage *= 100;
@@ -266,13 +287,20 @@ $(document).ready(function() {
         }, 900, 'swing');
     });
 
-    $("#pay-amount").focus();
+    $("#pay-amount-day").focus();
 
     // initialize dropdown selects
     $("#pay-rate").selectpicker().on("change", function() {
+        update_sliders($("#pay-rate").val());
         update_output();
     })
-    $("#pay-amount").on("change", function() {
+    $("#pay-amount-day").on("change", function() {
+        update_output();
+    })
+    $("#pay-amount-week").on("change", function() {
+        update_output();
+    })
+    $("#pay-amount-month").on("change", function() {
         update_output();
     })
     $('#assumption-container .selectpicker').selectpicker().on("change",function() {


### PR DESCRIPTION
This PR splits the slider into 3 separate sliders for day/week/month that are hidden/shown as the pay rate changes.

This allows the sliders to have different min/max values and scales depending on which rate is being used.
This also means that the position of the slider handle is better placed in the slider.

![day-pay-slider](https://user-images.githubusercontent.com/491346/47876717-a5fee580-de22-11e8-8b44-7b343e80a9ad.png)
