### PR TITLE
Make expense group icons responsive.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -384,3 +384,22 @@ h1, h2, h3, h4, h5, h6{
 	font-size: 0.8em;
 
 }
+
+@media (max-width: 767px){
+    .panel .fa-3x {
+        font-size: 1.5em;
+    }
+
+    .panel .slider {
+        margin-bottom: 0;
+    }
+
+    .panel .panel-image {
+        padding-top: 0;
+        padding-bottom: 20px;
+    }
+
+    .panel .form-group {
+        margin-bottom: 0;
+    }
+}


### PR DESCRIPTION
Fixes #4 - Before on left, After on right.

![expense-group-icons-before-after](https://user-images.githubusercontent.com/491346/53191175-d3f77800-3613-11e9-81e8-67a19784defa.png)
